### PR TITLE
Enable optional installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
     },
     "require": {
         "php": ">=8.0.2",
-        "ext-smbclient": "*",
         "icewind/smb": "^3.5",
         "league/flysystem": "^3.0"
     },
@@ -46,6 +45,9 @@
         "orchestra/testbench": "^7.7",
         "phpstan/phpstan": "^1.4",
         "phpunit/phpunit": "^9.5"
+    },
+    "suggest": {
+        "ext-smbclient": "Required to use this package"
     },
     "extra": {
         "laravel": {


### PR DESCRIPTION
Reason for this change - I would like to use this adapter optionally, when project runs on supported systems. On unsupported systems (windows server, missing extension) I'm not able to use it - that's fine.

