### PR TITLE
Added support for directory detection. 

### DIFF
--- a/src/SmbAdapter.php
+++ b/src/SmbAdapter.php
@@ -51,7 +51,15 @@ class SmbAdapter implements FilesystemAdapter
 
     public function directoryExists(string $path): bool
     {
-        return $this->fileExists($path);
+        $location = $this->prefixer->prefixPath($path);
+
+        try {
+            $info = $this->share->stat($location);
+        } catch (NotFoundException) {
+            return false;
+        }
+
+        return $info->isDirectory();
     }
 
     public function write(string $path, string $contents, Config $config): void


### PR DESCRIPTION
The `directoryExists` function at the moment is an alias for `fileExists`.
This can lead to a confusion and is inconsistent with the implementation of other flysystem adapters
(e.g. `league/flysystem-sftp-v3`).

The fix utilizes the `IFileInfo` `isDirectory` function to determine if a file is a directory.